### PR TITLE
WM-82: Remove scopes to make extension less permissive

### DIFF
--- a/components/GitHubLoginLink.tsx
+++ b/components/GitHubLoginLink.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 const GitHubLoginLink = ({ userEmail }) => (
   <div className="Box">
     <Link
-      href={`https://github.com/login/oauth/authorize?client_id=8543242e428085df968c&redirect_uri=https://app.watermelontools.com/github&state=${userEmail}&scope=repo%20user%20notifications`}
+      href={`https://github.com/login/oauth/authorize?client_id=8543242e428085df968c&redirect_uri=https://app.watermelontools.com/github&state=${userEmail}&scope=repo`}
     >
       <a className="button block">
         <div className="Box d-flex flex-items-center flex-justify-start p-2">


### PR DESCRIPTION
This change removes the `user` and `notifications` scopes. Below the descriptions of such (which self-explain why we don't need them). 
- `user`: Grants read/write access to profile info only. Note that this scope includes user:email and user:follow
- `notifications`: Grants:read access to a user's notificationsmark as read access to threadswatch and unwatch access to a repository, andread, write, and delete access to thread subscriptions.

We want to get access to pull requests in private repositories, and[ the only way to do so](https://stackoverflow.com/questions/26372417/github-oauth2-token-how-to-restrict-access-to-read-a-single-private-repo) is with the `repo` scope. 

Unfortunately, `public_repo` doesn't have a public repo equivalent. `read:repo_hook` is not what we're looking for(?)


