### PR TITLE
WM-85: Enhance JQL Query to find most relevant Jira ticket

### DIFF
--- a/pages/api/jira/getMostRelevantJiraTicket.ts
+++ b/pages/api/jira/getMostRelevantJiraTicket.ts
@@ -59,7 +59,7 @@ export default async function handler(req, res) {
       body: JSON.stringify({
         // ORDER BY issuetype ASC gives priority to bug tickets. If there are no bug tickets, it will still return stories
         // Sorting by description might be better than completely filtering out tickets without a description
-        jql: `text ~ "${parsedPRTitle}" AND issuetype in (Bug, Story) ORDER BY issuetype ASC, "Story Points" DESC, description DESC`,
+        jql: `text ~ "${parsedPRTitle}" AND issuetype in (Bug, Story, Task, Sub-task, Epic) ORDER BY issuetype ASC, "Story Points" DESC, description DESC`,
         expand: ["renderedFields"],
       }),
     }


### PR DESCRIPTION
**Quick udpate on this spike-ish story:**
- I’ve added a prioritization to return bug tickets first, followed by story tickets
- I’ve also added story point sorting
- I’ve also sorted by description. This might be smarter than completely filtering out tickets without a description, because there might be early stage teams like us who are not very thorough with their ticketing process yet, but a ticket without a description tells a lot by its sole title. 
- We can filter by wether they have links to Zendesk tickets or not. Perhaps we should work on that later once we have settings. I suspect this is a cool corporate/corporate thing. 


These set of heuristics combined, make creation date something way less relevant for our Jira ticket searching algorithm. 