### PR TITLE
Add Calendly link to billing page

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,7 +6,7 @@ export default function Navbar({ children }: { children: React.ReactNode }) {
     { href: "/", label: "Home" },
     { href: "/settings", label: "Settings" },
     { href: "/team", label: "Team" },
-    { href: "/billing", label: "Billing" },
+    { href: "https://calendly.com/evargas-14/watermelon-business", label: "Billing" },
   ];
   return (
     <div


### PR DESCRIPTION
As we fine-tune our billing system and address the complexities that doing such thing implies (orgs, seats, tiers, a custom UI), let's just point to a Calendly link while we run initial monetization experiments