### PR TITLE
Feature/watermelon as a team tool

### DIFF
--- a/app/api/actions/github/route.ts
+++ b/app/api/actions/github/route.ts
@@ -61,8 +61,9 @@ export async function POST(request: Request) {
 
       const octokit = await app.getInstallationOctokit(installationId);
 
-      const query = `EXEC dbo.get_all_tokens_from_gh_username @github_user='${userLogin}'`;
+      const query = `EXEC dbo.get_all_tokens_from_all_gh_teammates @github_user='${userLogin}'`;
       const wmUserData = await executeRequest(query);
+
       const {
         github_token,
         jira_token,
@@ -84,6 +85,7 @@ export async function POST(request: Request) {
         user_email,
         watermelon_user,
       } = wmUserData;
+
       if (!watermelon_user) {
         {
           // Post a new comment if no existing comment was found

--- a/app/api/extension/getContext/route.ts
+++ b/app/api/extension/getContext/route.ts
@@ -38,7 +38,9 @@ export async function POST(request: Request) {
     missingParamsPosthogTracking({ url: request.url, missingParams });
     return missingParamsResponse({ missingParams });
   }
-  const query = `EXEC dbo.get_all_user_tokens @watermelon_user='${req.email}'`;
+  // const query = `EXEC dbo.get_all_user_tokens @watermelon_user='${req.email}'`;
+  const query = `EXEC dbo.get_org_tokens @watermelon_user='${req.email}'`;
+
   let wmUserData = await executeRequest(query);
   const {
     github_token,

--- a/app/api/extension/getContext/route.ts
+++ b/app/api/extension/getContext/route.ts
@@ -38,8 +38,7 @@ export async function POST(request: Request) {
     missingParamsPosthogTracking({ url: request.url, missingParams });
     return missingParamsResponse({ missingParams });
   }
-  // const query = `EXEC dbo.get_all_user_tokens @watermelon_user='${req.email}'`;
-  const query = `EXEC dbo.get_org_tokens @watermelon_user='${req.email}'`;
+  const query = `EXEC dbo.get_all_user_tokens @watermelon_user='${req.email}'`;
 
   let wmUserData = await executeRequest(query);
 

--- a/app/api/extension/getContext/route.ts
+++ b/app/api/extension/getContext/route.ts
@@ -42,6 +42,7 @@ export async function POST(request: Request) {
   const query = `EXEC dbo.get_org_tokens @watermelon_user='${req.email}'`;
 
   let wmUserData = await executeRequest(query);
+
   const {
     github_token,
     jira_token,
@@ -64,6 +65,7 @@ export async function POST(request: Request) {
   } = wmUserData;
   try {
     wmUserData = await executeRequest(query);
+    console.log("WM User Data:", wmUserData);
   } catch (error) {
     console.error(
       "An error occurred while getting user tokens:",


### PR DESCRIPTION
## Description
Our GitHub app currently contextualizes the PRs only for the users who authorized Watermelon, not the entire team in an organization. 

This draft PR explores an initial approach that creates a stored procedure that queries for the org tokens of teammates of the same organization. This has challenges which I'll detail in the notes section. 

EDIT: Sending the final version of the Pull Request now. The new stored procedure:
- Looks for teammates (people with the same company on dbo.github)
- Gets the teammate who has a github_token, as we need to return a signgle user on the JSON
- Various teammates might exist, so we'll just return the teammate who has the most recent updated_at date (I thought it was a better heuristic than 'the oldest or the newest created_at date' to determine who's the user being in charge of adding integrations via the WM dashboard). 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
The challenges with this approach are:
- It requires that the 'company' value in the dbo.github table is consistent. 'company' is what you have on your GitHub bio, not the org you belong to, which makes it fail
- A potential fix for this is to modify the `saveUserInfo` method to not use the company in your GitHub bio as the 'company', but instead the GitHub org you are authorizing Watermelon to as the 'company'
- However the obstacle that I've found to implement the idea above is that This endpoint     fetch(`https://github.com/login/oauth/access_token`, {
 Provides a list of orgs that the user who authorized the oAuth access to belongs to, but not the org for which the user authorized Watermelon 
 - The approach has another point of failure which is that it requires PR authors to authenticate to be able to perform the query that searches for the tokens of their teammates. So although this would make us move one step forward, we would still have a bigger part of the problem to traverse. 

EDIT: 
- After studying GitHub's oAuth flow (both the one in our app, as well as ones in other apps): I concluded that we're doing it just right and that contexualizing everyone's PRs is not about modifying this but rather about how we trigger the pull_request webhook. This PR is just the starting point.
 
## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 