### PR TITLE
Feature/add ownership and date

### DIFF
--- a/utils/actions/markdownHelpers/helper.ts
+++ b/utils/actions/markdownHelpers/helper.ts
@@ -1,5 +1,5 @@
 import { MarkdownRequest, MarkdownResponse } from "../../../types/watermelon";
-import  getRelativeDate  from "../../getRelativeDate";
+import getRelativeDate from "../../getRelativeDate";
 
 type generalMarkdown = MarkdownRequest & {
   systemName: string;
@@ -20,22 +20,14 @@ const generalMarkdownHelper = ({
   let markdown: MarkdownResponse = ``;
   if (Array.isArray(value.data) && value?.data?.length) {
     markdown = `\n #### ${systemResponseName}`;
-
-    if (systemName === "GitHub") {
-      markdown += (value?.data || [])
-        .map(
-          ({ number, title, link, body, created_at, author}) =>
-            `\n - [#${number} - ${title}](${link}) - By ${author} ${getRelativeDate(created_at || "")} \n`
-        )
-        .join("");
-    } else {
-      markdown += (value?.data || [])
-        .map(
-          ({ number, title, link, body }) =>
-            `\n - [#${number} - ${title}](${link})\n`
-        )
-        .join("");
-    }
+    markdown += (value?.data || [])
+      .map(
+        ({ number, title, link, body, author, created_at }) =>
+          `\n - [#${number} - ${title}](${link}) ${
+            author ? ` - By ${author}` : ""
+          } ${created_at ? `${getRelativeDate(created_at ?? "")}` : ""}\n`
+      )
+      .join("");
   } else {
     markdown += `\n No results found in **${systemResponseName}** :( \n`;
   }


### PR DESCRIPTION
## Description
This small PR allows us to provide PR authorship and longevity, which is a change that allows us to show value the same way which we're already doing with our VS Code extension. Looks like this: 

<img width="763" alt="Screen Shot 2023-09-19 at 5 15 25 PM" src="https://github.com/watermelontools/watermelon/assets/8325094/9f3668a5-e72b-40a0-a6a9-14f4c3051c99">

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC 
 
## Notes
Not all services have the possibility of retrieving a date. But for those that do, we also have the opportunity to add this info to such on a separate PR 

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 