### PR TITLE
Remove organization as a mandtory paramater for running the GH app

### DIFF
--- a/app/api/actions/github/route.ts
+++ b/app/api/actions/github/route.ts
@@ -33,7 +33,6 @@ export async function POST(request: Request) {
   const { missingParams } = validateParams(req, [
     "pull_request",
     "repository",
-    "organization",
     "action",
     "number",
   ]);


### PR DESCRIPTION
## Description
What's currently happening is that we are requiring organization as a mandatory parameter, which makes us fail on personal repos. We know for a fact that people like to try out these kinds of tools on a personal repo first before adding it to a company repo.

This fix allows us to run on personal repos. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 