### PR TITLE
Feature/trinary pr labeling

### DIFF
--- a/app/api/actions/github/route.ts
+++ b/app/api/actions/github/route.ts
@@ -403,6 +403,7 @@ export async function POST(request: Request) {
       });
       textToWrite += randomText();
 
+      console.log("labelpullrequest will be called")
       // Make Watermelon Review the PR's business logic here by comparing the title with the AI-generated summary
       await labelPullRequest({
         prTitle: title,

--- a/app/api/actions/github/route.ts
+++ b/app/api/actions/github/route.ts
@@ -403,7 +403,6 @@ export async function POST(request: Request) {
       });
       textToWrite += randomText();
 
-      console.log("labelpullrequest will be called")
       // Make Watermelon Review the PR's business logic here by comparing the title with the AI-generated summary
       await labelPullRequest({
         prTitle: title,

--- a/utils/actions/labelPullRequest.ts
+++ b/utils/actions/labelPullRequest.ts
@@ -38,21 +38,6 @@ export default async function flagPullRequest({
 }) {
   const octokit = await app.getInstallationOctokit(installationId);
 
-  const { missingParams } = validateParams("", [
-    "prTitle",
-    "businessLogicSummary",
-    "installationId",
-    "owner",
-    "repo",
-    "issue_number",
-    "reqUrl",
-    "reqEmail",
-  ]);
-
-  if (missingParams.length > 0) {
-    return missingParamsResponse({ url: reqUrl, missingParams });
-  }
-
   const prompt = `The goal of this PR is to: ${prTitle}. \n The information related to this PR is: ${businessLogicSummary}. \n On a scale of 1(very different)-10(very similar), how similar the PR's goal and the PR's related information are? Take into account semantics. Don't explain your reasoning, just print the rating. Don't give a range for the rating, print a single value.`;
 
   try {
@@ -79,7 +64,9 @@ export default async function flagPullRequest({
           },
         });
 
-        if (prRating >= 2) {
+        console.log("prRating", prRating);
+
+        if (prRating >= 9) {
           octokit.request(
             "POST /repos/{owner}/{repo}/issues/{issue_number}/labels", //add label
             {
@@ -89,7 +76,18 @@ export default async function flagPullRequest({
               labels: ["🍉 Safe to Merge"],
             }
           );
-        } else {
+        } else if (prRating > 6) {
+          octokit.request(
+            "POST /repos/{owner}/{repo}/issues/{issue_number}/labels", //add label
+            {
+              owner,
+              repo,
+              issue_number,
+              labels: ["⚠️ Take a deeper dive"],
+            }
+          );
+        }
+        else {
           // remove label
           octokit.request(
             "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
@@ -98,6 +96,17 @@ export default async function flagPullRequest({
               repo,
               issue_number,
               name: "🍉 Safe to Merge",
+            }
+          );
+
+          // add label
+          octokit.request(
+            "POST /repos/{owner}/{repo}/issues/{issue_number}/labels", //add label
+            {
+              owner,
+              repo,
+              issue_number,
+              labels: ["🚨 Don't Merge"],
             }
           );
         }

--- a/utils/actions/labelPullRequest.ts
+++ b/utils/actions/labelPullRequest.ts
@@ -53,7 +53,7 @@ export default async function flagPullRequest({
       })
       .then((result) => {
         const prRating = result.data.choices[0].message.content;
-
+        
         successPosthogTracking({
           url: reqUrl,
           email: reqEmail,
@@ -65,6 +65,28 @@ export default async function flagPullRequest({
         });
 
         if (prRating >= 9) {
+          // remove label
+          octokit.request(
+            "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
+            {
+              owner,
+              repo,
+              issue_number,
+              name: "⚠️ Take a deeper dive",
+            }
+          );
+
+          // remove label
+          octokit.request(
+            "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
+            {
+              owner,
+              repo,
+              issue_number,
+              name: "🚨 Don't Merge",
+            }
+          );
+
           octokit.request(
             "POST /repos/{owner}/{repo}/issues/{issue_number}/labels", //add label
             {
@@ -75,6 +97,28 @@ export default async function flagPullRequest({
             }
           );
         } else if (prRating > 6) {
+          // remove label
+          octokit.request(
+            "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
+            {
+              owner,
+              repo,
+              issue_number,
+              name: "🍉 Safe to Merge",
+            }
+          );
+
+          // remove label
+          octokit.request(
+            "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
+            {
+              owner,
+              repo,
+              issue_number,
+              name: "🚨 Don't Merge",
+            }
+          );
+
           octokit.request(
             "POST /repos/{owner}/{repo}/issues/{issue_number}/labels", //add label
             {
@@ -94,6 +138,17 @@ export default async function flagPullRequest({
               repo,
               issue_number,
               name: "🍉 Safe to Merge",
+            }
+          );
+
+          // remove label
+          octokit.request(
+            "DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}",
+            {
+              owner,
+              repo,
+              issue_number,
+              name: "⚠️ Take a deeper dive",
             }
           );
 

--- a/utils/actions/labelPullRequest.ts
+++ b/utils/actions/labelPullRequest.ts
@@ -53,7 +53,7 @@ export default async function flagPullRequest({
       })
       .then((result) => {
         const prRating = result.data.choices[0].message.content;
-        
+
         successPosthogTracking({
           url: reqUrl,
           email: reqEmail,
@@ -72,7 +72,7 @@ export default async function flagPullRequest({
               owner,
               repo,
               issue_number,
-              name: "⚠️ Take a deeper dive",
+              name: "👀 Take a deeper dive",
             }
           );
 
@@ -125,7 +125,7 @@ export default async function flagPullRequest({
               owner,
               repo,
               issue_number,
-              labels: ["⚠️ Take a deeper dive"],
+              labels: ["👀 Take a deeper dive"],
             }
           );
         }
@@ -148,7 +148,7 @@ export default async function flagPullRequest({
               owner,
               repo,
               issue_number,
-              name: "⚠️ Take a deeper dive",
+              name: "👀 Take a deeper dive",
             }
           );
 

--- a/utils/actions/labelPullRequest.ts
+++ b/utils/actions/labelPullRequest.ts
@@ -64,8 +64,6 @@ export default async function flagPullRequest({
           },
         });
 
-        console.log("prRating", prRating);
-
         if (prRating >= 9) {
           octokit.request(
             "POST /repos/{owner}/{repo}/issues/{issue_number}/labels", //add label


### PR DESCRIPTION
## Description
Because we want to provide more feedback while maintaining strictness about what's a PR pre-approval and what's not, we're adding a trinary PR labeling system to our GitHub app. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
Possibly due to the recent permission changes, the github params validation wasn't working so I removed that piece of logic in` labelPullRequest.ts`

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 