### PR TITLE
Fix indexing issue for the single line file border-case

### DIFF
--- a/app/api/actions/github/route.ts
+++ b/app/api/actions/github/route.ts
@@ -414,6 +414,18 @@ export async function POST(request: Request) {
       });
       textToWrite += randomText();
 
+      // Detect console.logs and its equivalent in other languages
+      await detectConsoleLogs({
+        prTitle: title,
+        businessLogicSummary,
+        repo,
+        owner,
+        issue_number: number,
+        installationId,
+        reqUrl: request.url,
+        reqEmail: req.email,
+      });
+
       // Make Watermelon Review the PR's business logic here by comparing the title with the AI-generated summary
       await labelPullRequest({
         prTitle: title,

--- a/utils/actions/detectConsoleLogs.ts
+++ b/utils/actions/detectConsoleLogs.ts
@@ -74,9 +74,9 @@ function getConsoleLogPosition(filePatchAndIndividualLine: any) {
 
   // get the position of the indiviudalLine in th filePatch
   const lines = filePatch.split("\n");
-  for (let i = 0; i < lines.length; i++) {
+  for (let i = 1; i < lines.length; i++) {
     if (lines[i].includes(individualLine)) {
-      positionInDiff = i + 1;
+      positionInDiff = i;
       break;
     }
   }
@@ -159,6 +159,11 @@ export default async function detectConsoleLogs({
                 .then((result) => {
                   const latestCommitHash = result.data.head.sha;
 
+                  const consoleLogPosition = getConsoleLogPosition({
+                    filePatch: file.patch ?? "",
+                    individualLine
+                  }) 
+
                   return octokit.request(
                     "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
                     {
@@ -171,10 +176,7 @@ export default async function detectConsoleLogs({
                       comments: [
                         {
                           path: file.filename,
-                          position: getConsoleLogPosition({
-                            filePatch: file.patch ?? "",
-                            individualLine
-                          }) || 1, // comment at the beggining of the file by default
+                          position: consoleLogPosition || 1, // comment at the beggining of the file by default
                           body: "This file contains at least one console log. Please remove any present.",
                         },
                       ],


### PR DESCRIPTION
## Description
We were not commenting detected console logs on the line diffs of mono-line files. This PR fixes that border case. 

Look at the test comments on https://github.com/watermelontools/watermelon/pull/345/files for reference.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 