### PR TITLE
Spike/detect other security errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "applicationinsights": "^2.5.1",
     "client-only": "0.0.1",
     "md-to-adf": "^0.6.4",
-    "next": "latest",
+    "next": "^13",
     "next-auth": "^4.22.1",
     "nodemailer": "^6.7.8",
     "octokit": "^2.0.9",

--- a/utils/actions/detectConsoleLogs.ts
+++ b/utils/actions/detectConsoleLogs.ts
@@ -158,7 +158,7 @@ export default async function detectConsoleLogs({
     try {
       return await openai
         .createChatCompletion({
-          model: "gpt-3.5-turbo-16k",
+          model: "gpt-4-1106-preview",
           messages: [
             {
               role: "system",

--- a/utils/actions/detectConsoleLogs.ts
+++ b/utils/actions/detectConsoleLogs.ts
@@ -133,9 +133,10 @@ export default async function detectConsoleLogs({
     Other console functions such as console.info() shouldn't be counted as console logs.
     Ignore code comments from this analysis. 
     If there is a console log, return "true", else return "false".
-    If you return true, return a string that that has 2 values: result (true) and the line of code.
+    If you return true, return a string that that has 3 values: result (true), the line of code,
+      and the vulnerability type detected with is consoleLog in this case.
     The line value, is the actual line in the file that contains the console log.
-    For example: true,console.log("hello world");
+    For example: true,console.log("hello world");,console log
     
     Second:
     If there's an exposed environment variable or environment secret. 
@@ -147,9 +148,10 @@ export default async function detectConsoleLogs({
     For example: API_KEY=process.env.OPENAI_API_KEY is fine. 
     However, something like API_KEY='abcd1234' is not.
     If there is an exposed environment secret, return "true", else return "false".
-    If you return true, return a string that that has 2 values: result (true) and the line of code.
+    If you return true, return a string that that has 3 values: result (true), the line of code,
+      and the vulnerability type detected with is exposedEnvSecret in this case.
     The line value, is the actual line in the file that contains the exposed environment secret.
-    For example: true,const API_KEY='abcd1234';
+    For example: true,const API_KEY='abcd1234';,exposed environment secret
     `;
 
     // detect if the additions contain console logs or not
@@ -170,6 +172,7 @@ export default async function detectConsoleLogs({
 
           const addtionsHaveConsoleLog = openAIResult[0];
           const individualLine = openAIResult[1];
+          const vulnerabilityTypeDetected = openAIResult[2];
 
           if (addtionsHaveConsoleLog === "true") {
             const commentFileDiff = () => {
@@ -201,7 +204,7 @@ export default async function detectConsoleLogs({
                           {
                             path: file.filename,
                             position: consoleLogPosition || 1, // comment at the beggining of the file by default
-                            body: "This file contains at least one console log. Please remove any present.",
+                            body: `This file contains at least one ${vulnerabilityTypeDetected}. Please remove any present.`,
                           },
                         ],
                       }


### PR DESCRIPTION
## Description
Detecting security vulnerabilities is giving us early success. We're doubling down on this effort by expanding this function to detect exposed environment secrets as well. 

What the prompt returns is also expanded with a third parameter, so that what the bot commenst on the line diff is programmatic according to the type of vulnerability detected. This way, we can easily expand this function to even more types of vulnerabilities. 

## Type of change
<!--  Please delete options that are not relevant or write your own. -->
- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
- Exposed env secrets are already detected by GitHub's bot, but it's a very good way to test how expandable this function is into more complex vulnerabilities. It's an easy kind of vulnerability to test
- I'll test this with different commits in a separate PR

## Acceptance
<!--  We need to make sure everything stays up to standard. -->
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 