### PR TITLE
Bugfix - Deactivate comenting on bot PRs

### DIFF
--- a/app/api/actions/github/route.ts
+++ b/app/api/actions/github/route.ts
@@ -66,6 +66,12 @@ export async function POST(request: Request) {
 
       const octokit = await app.getInstallationOctokit(installationId);
 
+      if (pull_request.user.type === "Bot") {
+        return new Response("We don't comment on bot PRs", {
+          status: 400
+        });
+      }
+
       let octoCommitList = await octokit.request(
         "GET /repos/{owner}/{repo}/pulls/{pull_number}/commits",
         {


### PR DESCRIPTION
## Description
A user reported he wouldn't like this to happen. We solve this by returning 400 if PR author user type is a bot

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
- I tested both with bot PR https://github.com/watermelontools/watermelon-intellij/pull/66 and non-bot PR https://github.com/watermelontools/watermelon/pull/387 and both behave expacted (no commenting and commenting respectively). 
-  I added dependabot to this repo to track this change as time goes on 

## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 