### PR TITLE
Bugfix/new counter

### DIFF
--- a/utils/api/updateGitHubCounts.ts
+++ b/utils/api/updateGitHubCounts.ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import updateGitHubQueryCounts from '../../utils/db/github/updateGitHubQueryCounts'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+
+  try {
+    const data = await updateGitHubQueryCounts()
+    res.status(200).json(data)
+  } catch (error) {
+    console.error(error)
+    res.status(500).json({error: 'Error updating GitHub counts'})
+  }
+}

--- a/utils/db/github/updateGitHubQueryCounts.ts
+++ b/utils/db/github/updateGitHubQueryCounts.ts
@@ -2,7 +2,7 @@ import executeRequest from "../azuredb";
 
 export default async function updateGitHubQueryCounts(): Promise<any> {
   try {
-    let data = await executeRequest(`EXEC dbo.update_git_query_counts`);
+    let data = await executeRequest(`EXEC dbo.update_github_query_counts`);
     return { data };
   } catch (err) {
     console.error(err);

--- a/utils/db/teams/addActionCount.ts
+++ b/utils/db/teams/addActionCount.ts
@@ -2,7 +2,8 @@ import executeRequest from "../azuredb";
 
 export default async ({ owner }) => {
   let query = await executeRequest(
-    `EXEC dbo.increment_owner_github_app_uses @watermelon_user = '${owner}'`
+    `EXEC dbo.increment_owner_github_app_uses @owner = '${owner}'`
   );
+  console.log("return query", query);
   return query;
 };

--- a/utils/db/teams/addActionCount.ts
+++ b/utils/db/teams/addActionCount.ts
@@ -4,6 +4,5 @@ export default async ({ owner }) => {
   let query = await executeRequest(
     `EXEC dbo.increment_owner_github_app_uses @owner = '${owner}'`
   );
-  console.log("return query", query);
   return query;
 };

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+    "crons": [
+      {
+        "path": "/api/cron",
+        "schedule": "0 0 1 * *"
+      }
+    ]
+  }


### PR DESCRIPTION
## Description
To be able to limit free usage in private repos, this bugfix changes the stored procedure linked to the task and adds a vercel.json file to be able to call such stored procedure periodically (every month). 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC  

## Notes
- I incorrectly stated that we were counting comments as an interaction. This was already fine. Only counting PR analyses
- I changed names to be more idiomatic (github instead of git). It's better guidance for us. 
- Vercel CRONs only work in prod deployments. We still gotta test this 

Here's a video showing the count is correctly updated 

https://github.com/watermelontools/watermelon/assets/8325094/6edd9e29-228f-4d30-ad61-768ade931a8d


## Acceptance
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 