### PR TITLE
Feature/better console log detection

### DIFF
--- a/utils/actions/detectConsoleLogs.ts
+++ b/utils/actions/detectConsoleLogs.ts
@@ -110,10 +110,16 @@ export default async function detectConsoleLogs({
     const { additions } = getLineDiffs(file.patch ?? "");
 
     const splitAdditions = additions.split("\n");
+
+    // RegEx to detect console log equivalents in different languages
     const consoleLogRegex = /(console\.log|print|printf|fmt\.Print|log\.Print|NSLog|puts|println|println!)\([^)]*\)(?![^]*?\/\/|[^]*?\/\*|#)/;
+    
+    // RegEx to ignore lines that contian //, /*, etc.
+    const commentRegex = /^\s*\/{2,}|^\s*\/\*|\*\/|#/;
 
     for (let i=0; i < splitAdditions.length; i++) {
-      if (splitAdditions[i].match(consoleLogRegex)) {
+      let currentLine = splitAdditions[i];
+      if (!currentLine.match(commentRegex) && currentLine.match(consoleLogRegex)) {
         const commentFileDiff = async () => {
 
           const consoleLogPosition = i + 1; // The +1 is because IDEs and GitHub file diff view index LOC at 1, not 0

--- a/utils/actions/detectConsoleLogs.ts
+++ b/utils/actions/detectConsoleLogs.ts
@@ -11,20 +11,6 @@ const app = new App({
   privateKey: process.env.GITHUB_PRIVATE_KEY!,
 });
 const commentBody = `This PR contains console logs. Please review or remove them.`;
-const consoleLogDetectionPrompt = `This is a list of code additions. Identify 
-if there's a console log or its equivalent in another programming language 
-such as Java, Golang, Python, C, Rust, C++, Ruby, etc.
-(console.log(), println(), println!(), System.out.println(), print(), fmt.Println(), puts, and  cout << "Print a String" << endl; are some examples). 
-If the console log or its equivalent in another language is in a code comment, don't
-count it as a detected console log. For example JavaScript comments start with // or /*, 
-Python comments start with #.
-Other console functions such as console.info() shouldn't be counted as console logs.
-Ignore code comments from this analysis. 
-Something like 'input[type="email"]' is fine and should not be counted as a console log.
-If there is a console log, return "true", else return "false".
-If you return true, return a string that that has 2 values: result (true) and the line of code.
-The line value, is the actual line in the file that contains the console log.
-For example: true,console.log("hello world");`;
 
 function getLineDiffs(filePatch: string) {
   const additions: string[] = [];

--- a/utils/actions/detectConsoleLogs.ts
+++ b/utils/actions/detectConsoleLogs.ts
@@ -127,64 +127,6 @@ export default async function detectConsoleLogs({
       }
   
     }
-
-    // detect if the additions contain console logs or not OLD APPROACH
-    // try {
-    //   return await openai
-    //     .createChatCompletion({
-    //       model: "gpt-4-1106-preview",
-    //       messages: [
-    //         {
-    //           role: "system",
-    //           content: `${consoleLogDetectionPrompt} \n ${additions}`,
-    //         },
-    //       ],
-    //     })
-    //     .then((result) => {
-    //       const openAIResult =
-    //         result.data.choices[0].message.content.split(",");
-
-    //       const addtionsHaveConsoleLog = openAIResult[0];
-    //       const individualLine = openAIResult[1];
-
-    //       if (addtionsHaveConsoleLog === "true") {
-    //         const commentFileDiff = () => {
-    //           const consoleLogPosition = getConsoleLogPosition({
-    //             filePatch: file.patch ?? "",
-    //             individualLine,
-    //           });
-
-    //           return octokit
-    //             .request(
-    //               "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
-    //               {
-    //                 owner,
-    //                 repo,
-    //                 pull_number: issue_number,
-    //                 commit_id:
-    //                   typeof latestCommitHash === "string"
-    //                     ? latestCommitHash
-    //                     : undefined,
-    //                 event: "COMMENT",
-    //                 path: file.filename,
-    //                 comments: [
-    //                   {
-    //                     path: file.filename,
-    //                     position: consoleLogPosition || 1, // comment at the beggining of the file by default
-    //                     body: commentBody,
-    //                   },
-    //                 ],
-    //               }
-    //             )
-    //             .catch((err) => {
-    //               console.log(err);
-    //             });
-    //         };
-
-    //         commentFileDiff();
-    //       }
-    //     });
-    // } catch {}
   });
   try {
     await Promise.allSettled(commentPromises);

--- a/utils/actions/detectConsoleLogs.ts
+++ b/utils/actions/detectConsoleLogs.ts
@@ -109,10 +109,13 @@ export default async function detectConsoleLogs({
   const commentPromises = diffFiles.map(async (file) => {
     const { additions } = getLineDiffs(file.patch ?? "");
 
-    const consoleLogRegex =
-      "/(console.log|print|printf|fmt.Print|log.Print|NSLog|puts|println|println!)([^)]*)(?![^]*?//|[^]*?/*|#)/";
+    console.log("additions", additions);
 
-    if (additions.includes(consoleLogRegex)) {
+    const consoleLogRegex = /(console\.log|print|printf|fmt\.Print|log\.Print|NSLog|puts|println|println!)\([^)]*\)(?![^]*?\/\/|[^]*?\/\*|#)/;
+
+    // const consoleLogRegex = /console\.log[^;]+;/;
+
+    if (additions.match(consoleLogRegex)) {
       console.log("console log detected");
 
       const commentFileDiff = async () => {
@@ -149,8 +152,6 @@ export default async function detectConsoleLogs({
 
       commentFileDiff();
     }
-
-    console.log("additions[0]", additions[0]);
 
     // detect if the additions contain console logs or not OLD APPROACH
     // try {

--- a/utils/actions/detectConsoleLogs.ts
+++ b/utils/actions/detectConsoleLogs.ts
@@ -36,17 +36,6 @@ function getLineDiffs(filePatch: string) {
   return { additions: additions.join("\n"), removals: removals.join("\n") };
 }
 
-function getConsoleLogPosition({ filePatch, individualLine }) {
-  // Split the filePatch into lines and find the index of the line that includes individualLine
-  const lines = filePatch.split("\n");
-  const zeroBasedIndex = lines.findIndex((line) =>
-    line.includes(individualLine)
-  );
-
-  // Convert to one-based index, or return -1 if not found
-  return zeroBasedIndex === -1 ? 0 : zeroBasedIndex + 1;
-}
-
 export default async function detectConsoleLogs({
   installationId,
   owner,

--- a/utils/actions/detectConsoleLogs.ts
+++ b/utils/actions/detectConsoleLogs.ts
@@ -109,63 +109,71 @@ export default async function detectConsoleLogs({
   const commentPromises = diffFiles.map(async (file) => {
     const { additions } = getLineDiffs(file.patch ?? "");
 
-    // detect if the additions contain console logs or not
-    try {
-      return await openai
-        .createChatCompletion({
-          model: "gpt-4-1106-preview",
-          messages: [
-            {
-              role: "system",
-              content: `${consoleLogDetectionPrompt} \n ${additions}`,
-            },
-          ],
-        })
-        .then((result) => {
-          const openAIResult =
-            result.data.choices[0].message.content.split(",");
+    const consoleLogRegex = "/(console\.log|print|printf|fmt\.Print|log\.Print|NSLog|puts|println|println!)\([^)]*\)(?![^]*?\/\/|[^]*?\/\*|#)/"
 
-          const addtionsHaveConsoleLog = openAIResult[0];
-          const individualLine = openAIResult[1];
+    if (additions.includes(consoleLogRegex)) {
+      console.log("console log detected");
+    }
 
-          if (addtionsHaveConsoleLog === "true") {
-            const commentFileDiff = () => {
-              const consoleLogPosition = getConsoleLogPosition({
-                filePatch: file.patch ?? "",
-                individualLine,
-              });
+    console.log("additions[0]", additions[0]);
 
-              return octokit
-                .request(
-                  "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
-                  {
-                    owner,
-                    repo,
-                    pull_number: issue_number,
-                    commit_id:
-                      typeof latestCommitHash === "string"
-                        ? latestCommitHash
-                        : undefined,
-                    event: "COMMENT",
-                    path: file.filename,
-                    comments: [
-                      {
-                        path: file.filename,
-                        position: consoleLogPosition || 1, // comment at the beggining of the file by default
-                        body: commentBody,
-                      },
-                    ],
-                  }
-                )
-                .catch((err) => {
-                  console.log(err);
-                });
-            };
+    // detect if the additions contain console logs or not OLD APPROACH
+    // try {
+    //   return await openai
+    //     .createChatCompletion({
+    //       model: "gpt-4-1106-preview",
+    //       messages: [
+    //         {
+    //           role: "system",
+    //           content: `${consoleLogDetectionPrompt} \n ${additions}`,
+    //         },
+    //       ],
+    //     })
+    //     .then((result) => {
+    //       const openAIResult =
+    //         result.data.choices[0].message.content.split(",");
 
-            commentFileDiff();
-          }
-        });
-    } catch {}
+    //       const addtionsHaveConsoleLog = openAIResult[0];
+    //       const individualLine = openAIResult[1];
+
+    //       if (addtionsHaveConsoleLog === "true") {
+    //         const commentFileDiff = () => {
+    //           const consoleLogPosition = getConsoleLogPosition({
+    //             filePatch: file.patch ?? "",
+    //             individualLine,
+    //           });
+
+    //           return octokit
+    //             .request(
+    //               "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+    //               {
+    //                 owner,
+    //                 repo,
+    //                 pull_number: issue_number,
+    //                 commit_id:
+    //                   typeof latestCommitHash === "string"
+    //                     ? latestCommitHash
+    //                     : undefined,
+    //                 event: "COMMENT",
+    //                 path: file.filename,
+    //                 comments: [
+    //                   {
+    //                     path: file.filename,
+    //                     position: consoleLogPosition || 1, // comment at the beggining of the file by default
+    //                     body: commentBody,
+    //                   },
+    //                 ],
+    //               }
+    //             )
+    //             .catch((err) => {
+    //               console.log(err);
+    //             });
+    //         };
+
+    //         commentFileDiff();
+    //       }
+    //     });
+    // } catch {}
   });
   try {
     await Promise.allSettled(commentPromises);

--- a/utils/actions/detectConsoleLogs.ts
+++ b/utils/actions/detectConsoleLogs.ts
@@ -119,7 +119,7 @@ export default async function detectConsoleLogs({
               ],
             })
             .catch((err) => {
-              console.log(err);
+              throw err;
             });
         };
   


### PR DESCRIPTION
## Description
LLMs didn't prove to be the correct approach towards console log detection.

They were a fast way to test interest and some initial cases. But since this is a key need users have, we need to run these through RegExes to make the console log detection not too lax, and not too strict. 

I tested this with PR #412 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] Documentation update  
- [ ] Chore: cleanup/renaming, etc  
- [ ] RFC
- [ ] Test

## Notes
- Post-processing each addition in the line diff with AI is always an open option that we can go back to if we think about some application. 
- Let's leave the name of the file as it is. The logic in detectLeftoutComents.ts or detectPIIData.ts would eventually be different, despite being able to abstract some components such as commenting the line where the issues is found.  

## Acceptance
<!--  We need to make sure everything stays up to standard. -->
- [x] I have read [the Contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md) 
